### PR TITLE
JDP230402-16 Added classes: OrderEntityTests and OrderItemEntityTests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     implementation 'org.jetbrains:annotations:20.1.0'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/kodilla/ecommercee/domain/Group.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Group.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table (name = "GROUPS")
+@Table (name = "PRODUCT_GROUP")
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter

--- a/src/main/java/com/kodilla/ecommercee/domain/Order.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/Order.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.persistence.*;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @NoArgsConstructor
@@ -18,7 +19,7 @@ import java.util.List;
 @Table(name = "ORDERS")
 public class Order {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     @NotNull
     @Column(name = "ORDER_ID", unique = true)
     private Long orderId;
@@ -40,5 +41,5 @@ public class Order {
             mappedBy = "order",
             fetch = FetchType.LAZY
     )
-    private List<OrderItem> ordersItems;
+    private List<OrderItem> ordersItems = new ArrayList<>();
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/OrderItem.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/OrderItem.java
@@ -18,7 +18,7 @@ import java.math.BigDecimal;
 public class OrderItem {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue
     @NotNull
     @Column(name = "ORDER_ITEM_ID", unique = true)
     private Long orderItemId;

--- a/src/main/java/com/kodilla/ecommercee/domain/User.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/User.java
@@ -44,5 +44,5 @@ public class User {
             mappedBy = "user",
             fetch = FetchType.LAZY
     )
-    private List<Order> ordersId;
+    private List<Order> orders;
 }

--- a/src/main/java/com/kodilla/ecommercee/repository/OrderItemRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/OrderItemRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 @Transactional
 @Repository
 public interface OrderItemRepository extends CrudRepository<OrderItem, Long> {
+
+    @Override
     List<OrderItem> findAll();
 
     Optional<OrderItem> findById(Long Id);

--- a/src/main/java/com/kodilla/ecommercee/repository/OrderRepository.java
+++ b/src/main/java/com/kodilla/ecommercee/repository/OrderRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Repository
 public interface OrderRepository extends CrudRepository<Order, Long> {
 
+    @Override
     List<Order> findAll();
 
     Optional<Order> findById(Long Id);

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
@@ -123,9 +123,12 @@ public class OrderEntityTests {
         Order order = createOrder1();
         orderRepository.save(order);
         Long orderId = order.getOrderId();
+        OrderItem orderItem = order.getOrdersItems().get(0);
         // When
+        orderItemRepository.deleteById(orderItem.getOrderItemId());
         orderRepository.deleteById(orderId);
         // Then
         assertEquals(Optional.empty(), orderRepository.findById(orderId));
+        assertFalse(orderRepository.existsById(orderId));
     }
 }

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
@@ -28,8 +28,6 @@ public class OrderEntityTests {
     @Autowired
     UserRepository userRepository;
 
-    @Autowired
-    OrderItemRepository orderItemRepository;
 
     private Order createOrder1() {
         User user1 = new User();
@@ -39,11 +37,7 @@ public class OrderEntityTests {
         orderList1.add(order1);
 
         OrderItem orderItem1 = new OrderItem();
-        List<OrderItem> orderItemList1 = new ArrayList<>();
-        orderItemList1.add(orderItem1);
-
         orderItem1.setOrder(order1);
-        orderItemRepository.save(orderItem1);
 
         user1.setOrders(orderList1);
         userRepository.save(user1);
@@ -51,7 +45,7 @@ public class OrderEntityTests {
         order1.setOrderStatus("In progress");
         order1.setDateOfOrder(LocalDate.of(2023, 2, 2));
         order1.setUser(user1);
-        order1.setOrdersItems(orderItemList1);
+        order1.getOrdersItems().add(orderItem1);
 
         return order1;
     }
@@ -64,11 +58,7 @@ public class OrderEntityTests {
         orderList2.add(order2);
 
         OrderItem orderItem2 = new OrderItem();
-        List<OrderItem> orderItemList2 = new ArrayList<>();
-        orderItemList2.add(orderItem2);
-
         orderItem2.setOrder(order2);
-        orderItemRepository.save(orderItem2);
 
         user2.setOrders(orderList2);
         userRepository.save(user2);
@@ -76,7 +66,7 @@ public class OrderEntityTests {
         order2.setOrderStatus("In progress");
         order2.setDateOfOrder(LocalDate.of(2023, 2, 2));
         order2.setUser(user2);
-        order2.setOrdersItems(orderItemList2);
+        order2.getOrdersItems().add(orderItem2);
 
         return order2;
     }
@@ -123,9 +113,7 @@ public class OrderEntityTests {
         Order order = createOrder1();
         orderRepository.save(order);
         Long orderId = order.getOrderId();
-        OrderItem orderItem = order.getOrdersItems().get(0);
         // When
-        orderItemRepository.deleteById(orderItem.getOrderItemId());
         orderRepository.deleteById(orderId);
         // Then
         assertEquals(Optional.empty(), orderRepository.findById(orderId));

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderEntityTests.java
@@ -1,0 +1,131 @@
+package com.kodilla.ecommercee.domain;
+
+import com.kodilla.ecommercee.repository.OrderItemRepository;
+import com.kodilla.ecommercee.repository.OrderRepository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.kodilla.ecommercee.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+@Transactional
+@SpringBootTest
+public class OrderEntityTests {
+
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    OrderItemRepository orderItemRepository;
+
+    private Order createOrder1() {
+        User user1 = new User();
+
+        Order order1 = new Order();
+        List<Order> orderList1 = new ArrayList<>();
+        orderList1.add(order1);
+
+        OrderItem orderItem1 = new OrderItem();
+        List<OrderItem> orderItemList1 = new ArrayList<>();
+        orderItemList1.add(orderItem1);
+
+        orderItem1.setOrder(order1);
+        orderItemRepository.save(orderItem1);
+
+        user1.setOrders(orderList1);
+        userRepository.save(user1);
+
+        order1.setOrderStatus("In progress");
+        order1.setDateOfOrder(LocalDate.of(2023, 2, 2));
+        order1.setUser(user1);
+        order1.setOrdersItems(orderItemList1);
+
+        return order1;
+    }
+
+    private Order createOrder2() {
+        User user2 = new User();
+
+        Order order2 = new Order();
+        List<Order> orderList2 = new ArrayList<>();
+        orderList2.add(order2);
+
+        OrderItem orderItem2 = new OrderItem();
+        List<OrderItem> orderItemList2 = new ArrayList<>();
+        orderItemList2.add(orderItem2);
+
+        orderItem2.setOrder(order2);
+        orderItemRepository.save(orderItem2);
+
+        user2.setOrders(orderList2);
+        userRepository.save(user2);
+
+        order2.setOrderStatus("In progress");
+        order2.setDateOfOrder(LocalDate.of(2023, 2, 2));
+        order2.setUser(user2);
+        order2.setOrdersItems(orderItemList2);
+
+        return order2;
+    }
+
+    @Test
+    void testSaveOrder() {
+        // Given
+        Order order = createOrder1();
+        // When
+        orderRepository.save(order);
+        Long orderId = order.getOrderId();
+        // Then
+        assertNotEquals(0, orderId);
+    }
+
+    @Test
+    void testFindAllOrder() {
+        // Given
+        Order order1 = createOrder1();
+        Order order2 = createOrder2();
+        orderRepository.save(order1);
+        orderRepository.save(order2);
+        // When
+        List<Order> orderList = orderRepository.findAll();
+        // Then
+        assertEquals(2, orderList.size());
+    }
+
+    @Test
+    void testFindOrderById() {
+        // Given
+        Order order = createOrder1();
+        orderRepository.save(order);
+        // When
+        Optional<Order> orderReceived = orderRepository.findById(order.getOrderId());
+        // Then
+        assertTrue(orderReceived.isPresent());
+        assertEquals("In progress", orderReceived.get().getOrderStatus());
+    }
+
+    @Test
+    void testDeleteOrderById() {
+        // Given
+        Order order = createOrder1();
+        orderRepository.save(order);
+        Long orderId = order.getOrderId();
+        // When
+        orderRepository.deleteById(orderId);
+        // Then
+        assertEquals(Optional.empty(), orderRepository.findById(orderId));
+    }
+}

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
@@ -1,0 +1,130 @@
+package com.kodilla.ecommercee.domain;
+
+import com.kodilla.ecommercee.repository.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import javax.transaction.Transactional;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+public class OrderItemEntityTests {
+    @Autowired
+    OrderRepository orderRepository;
+
+    @Autowired
+    ProductRepository productRepository;
+
+    @Autowired
+    OrderItemRepository orderItemRepository;
+
+    @Autowired
+    GroupRepository groupRepository;
+
+    private OrderItem createOrderItem1() {
+        Order order1 = new Order();
+        Product product1 = new Product();
+        Group group1 = new Group();
+
+        OrderItem orderItem1 = new OrderItem();
+        List<OrderItem> orderItemList1 = new ArrayList<OrderItem>();
+        orderItemList1.add(orderItem1);
+
+        groupRepository.save(group1);
+
+        order1.setOrdersItems(orderItemList1);
+        orderRepository.save(order1);
+
+        product1.setOrderItem(orderItemList1);
+        product1.setGroup(group1);
+        productRepository.save(product1);
+
+        orderItem1.setOrder(order1);
+        orderItem1.setPrice(new BigDecimal(120));
+        orderItem1.setProduct(product1);
+        orderItem1.setProductQuantity(5);
+
+        return orderItem1;
+    }
+
+    private OrderItem createOrderItem2() {
+        Order order2 = new Order();
+        Product product2 = new Product();
+        Group group2 = new Group();
+
+        OrderItem orderItem2 = new OrderItem();
+        List<OrderItem> orderItemList2 = new ArrayList<>();
+        orderItemList2.add(orderItem2);
+
+        groupRepository.save(group2);
+
+        order2.setOrdersItems(orderItemList2);
+        orderRepository.save(order2);
+
+        product2.setOrderItem(orderItemList2);
+        product2.setGroup(group2);
+        productRepository.save(product2);
+
+        orderItem2.setOrder(order2);
+        orderItem2.setPrice(new BigDecimal(90));
+        orderItem2.setProduct(product2);
+        orderItem2.setProductQuantity(10);
+
+        return orderItem2;
+    }
+
+    @Test
+    void testSaveOrderItem() {
+        // Given
+        OrderItem orderItem = createOrderItem1();
+        // When
+        orderItemRepository.save(orderItem);
+        Long orderItemId = orderItem.getOrderItemId();
+        // Then
+        assertNotEquals(0, orderItemId);
+    }
+
+    @Test
+    void testFindAllOrderItem() {
+        // Given
+        OrderItem orderItem1 = createOrderItem1();
+        OrderItem orderItem2 = createOrderItem2();
+        orderItemRepository.save(orderItem1);
+        orderItemRepository.save(orderItem2);
+        // When
+        List<OrderItem> orderItemList = orderItemRepository.findAll();
+        // Then
+        assertEquals(2, orderItemList.size());
+    }
+
+    @Test
+    void testFindOrderItemById() {
+        // Given
+        OrderItem orderItem = createOrderItem1();
+        orderItemRepository.save(orderItem);
+        // When
+        Optional<OrderItem> orderItemReceived = orderItemRepository.findById(orderItem.getOrderItemId());
+        // Then
+        assertTrue(orderItemReceived.isPresent());
+        assertEquals(5, orderItemReceived.get().getProductQuantity());
+    }
+
+    @Test
+    void testDeleteOrderItemById() {
+        // Given
+        OrderItem orderItem = createOrderItem1();
+        orderItemRepository.save(orderItem);
+        Long orderItemId = orderItem.getOrderItemId();
+        // When
+        orderItemRepository.deleteById(orderItemId);
+        // Then
+        assertEquals(Optional.empty(), orderItemRepository.findById(orderItemId));
+    }
+
+}

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
@@ -31,17 +31,14 @@ public class OrderItemEntityTests {
         Order order1 = new Order();
         Product product1 = new Product();
         Group group1 = new Group();
-
         OrderItem orderItem1 = new OrderItem();
-        List<OrderItem> orderItemList1 = new ArrayList<OrderItem>();
-        orderItemList1.add(orderItem1);
 
         groupRepository.save(group1);
 
-        order1.setOrdersItems(orderItemList1);
+        order1.getOrdersItems().add(orderItem1);
         orderRepository.save(order1);
 
-        product1.setOrderItem(orderItemList1);
+        product1.getOrderItem().add(orderItem1);
         product1.setGroup(group1);
         productRepository.save(product1);
 
@@ -57,17 +54,14 @@ public class OrderItemEntityTests {
         Order order2 = new Order();
         Product product2 = new Product();
         Group group2 = new Group();
-
         OrderItem orderItem2 = new OrderItem();
-        List<OrderItem> orderItemList2 = new ArrayList<>();
-        orderItemList2.add(orderItem2);
 
         groupRepository.save(group2);
 
-        order2.setOrdersItems(orderItemList2);
+        order2.getOrdersItems().add(orderItem2);
         orderRepository.save(order2);
 
-        product2.setOrderItem(orderItemList2);
+        product2.getOrderItem().add(orderItem2);
         product2.setGroup(group2);
         productRepository.save(product2);
 

--- a/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
+++ b/src/test/java/com/kodilla/ecommercee/domain/OrderItemEntityTests.java
@@ -125,6 +125,7 @@ public class OrderItemEntityTests {
         orderItemRepository.deleteById(orderItemId);
         // Then
         assertEquals(Optional.empty(), orderItemRepository.findById(orderItemId));
+        assertFalse(orderItemRepository.existsById(orderItemId));
     }
 
 }


### PR DESCRIPTION
Added classes: OrderEntityTests and OrderItemEntityTests.

Minor changes:
- added `@Override` in repository for Order and OrderItem,
- changed field in class `User` from `private List<Order> orderId;` to `private List<Order> orders;`,
- changed field in class `Order` from `private List<OrderItem> ordersItems;` to `private List<OrderItem> ordersItems = new ArrayList<>();`
- added in `dependencies`: `testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'`,
- changed name of the table of Group entity,
- delete the annotation `(strategy = GenerationType.AUTO)` in Order and OrderItem entities